### PR TITLE
VL-28_Fix-isDefaultComponentConfig-mehtod_Dmytro-Holdobin

### DIFF
--- a/src/services/tailwindSafelist.service.js
+++ b/src/services/tailwindSafelist.service.js
@@ -166,7 +166,9 @@ function getComponentBrandColor(componentName) {
 }
 
 function isDefaultComponentConfig(filePath, componentName) {
-  return filePath.includes(components[componentName].folder) && filePath.endsWith("default.config.js");
+  const componentDirName = filePath.split(path.sep).at(1);
+
+  return componentDirName === components[componentName].folder && filePath.endsWith("default.config.js");
 }
 
 function getSafelistColorsFromConfig(componentName) {


### PR DESCRIPTION
Fixed issue when isDefaultComponentConfig returned true for wrong component which has similar name with target component

> https://ilevel.atlassian.net/browse/VL-32